### PR TITLE
Fix use `.CMD` server for windows

### DIFF
--- a/src/oxc.rs
+++ b/src/oxc.rs
@@ -36,9 +36,11 @@ impl OxcExtension {
                 || !f["devDependencies"][PACKAGE_NAME].is_null()
         });
 
+        let is_windows = zed::current_platform().0 == zed::Os::Windows;
+
         // On Windows, the direct server path is never used because Windows always requires the `.CMD` wrapper
         // from the `.bin` directory. Therefore, we only use the direct server path on non-Windows platforms.
-        if server_package_exists && zed::current_platform().0 != zed::Os::Windows {
+        if server_package_exists && !is_windows {
             let worktree_root_path = worktree.root_path();
             let path = Path::new(worktree_root_path.as_str())
                 .join(SERVER_PATH)
@@ -53,7 +55,7 @@ impl OxcExtension {
             &zed::LanguageServerInstallationStatus::CheckingForUpdate,
         );
 
-        let fallback_server_path = Path::new(if zed::current_platform().0 == zed::Os::Windows {
+        let fallback_server_path = Path::new(if is_windows {
             "./node_modules/.bin/oxc_language_server.CMD"
         } else {
             "./node_modules/.bin/oxc_language_server"

--- a/src/oxc.rs
+++ b/src/oxc.rs
@@ -5,13 +5,12 @@ use zed_extension_api::{
     settings::LspSettings,
 };
 
-const SERVER_PATH: &str = if cfg!(windows) {
-    "node_modules/oxlint/bin/oxc_language_server.exe"
-} else {
-    "node_modules/oxlint/bin/oxc_language_server"
-};
+// the general expected server path (excluded for windows)
+const SERVER_PATH: &str = "node_modules/oxlint/bin/oxc_language_server";
+
+// fallback to the wrapper script
 const FALLBACK_SERVER_PATH: &str = if cfg!(windows) {
-    "./node_modules/.bin/oxc_language_server.exe"
+    "./node_modules/.bin/oxc_language_server.CMD"
 } else {
     "./node_modules/.bin/oxc_language_server"
 };
@@ -43,7 +42,8 @@ impl OxcExtension {
                 || !f["devDependencies"][PACKAGE_NAME].is_null()
         });
 
-        if server_package_exists {
+        // windows needs the `.CMD` file, which is only inside `node_modules/.bin`.
+        if server_package_exists && !cfg!(windows) {
             let worktree_root_path = worktree.root_path();
             let path = Path::new(worktree_root_path.as_str())
                 .join(SERVER_PATH)

--- a/src/oxc.rs
+++ b/src/oxc.rs
@@ -1,15 +1,21 @@
 use std::{env, fs, path::Path};
 use zed_extension_api::{
-    self as zed,
+    self as zed, LanguageServerId, Result,
     serde_json::{self, Value},
     settings::LspSettings,
-    LanguageServerId, Result,
 };
 
-const SERVER_PATH: &str = "node_modules/oxlint/bin/oxc_language_server";
+const SERVER_PATH: &str = if cfg!(windows) {
+    "node_modules/oxlint/bin/oxc_language_server.exe"
+} else {
+    "node_modules/oxlint/bin/oxc_language_server"
+};
+const FALLBACK_SERVER_PATH: &str = if cfg!(windows) {
+    "./node_modules/.bin/oxc_language_server.exe"
+} else {
+    "./node_modules/.bin/oxc_language_server"
+};
 const PACKAGE_NAME: &str = "oxlint";
-const FALLBACK_SERVER_PATH: &str = "./node_modules/.bin/oxc_language_server";
-
 const OXC_CONFIG_PATHS: &[&str] = &[".oxlintrc.json"];
 
 struct OxcExtension;
@@ -67,8 +73,8 @@ impl OxcExtension {
                 Ok(()) => {
                     if !self.server_exists(fallback_server_path) {
                         Err(format!(
-              "installed package '{PACKAGE_NAME}' did not contain expected path '{fallback_server_path:?}'",
-            ))?;
+                            "installed package '{PACKAGE_NAME}' did not contain expected path '{fallback_server_path:?}'",
+                        ))?;
                     }
                 }
                 Err(error) => {


### PR DESCRIPTION
closes #16 

Not tested, but looks similar to https://github.com/oxc-project/oxc/pull/12932.

The target file has a sh shebang, but can not work under windows.
