### PR TITLE
fix(windows): Add workaround for leading / on Windows paths

### DIFF
--- a/src/oxc.rs
+++ b/src/oxc.rs
@@ -149,8 +149,7 @@ impl zed_extension_api::Extension for OxcExtension {
             }
         }
 
-        let bin = env::current_dir()
-            .unwrap()
+        let bin = zed_ext::sanitize_windows_path(env::current_dir().unwrap())
             .join(path)
             .to_string_lossy()
             .to_string();
@@ -172,3 +171,25 @@ impl zed_extension_api::Extension for OxcExtension {
 }
 
 zed_extension_api::register_extension!(OxcExtension);
+
+/// Extensions to the Zed extension API that have not yet stabilized.
+mod zed_ext {
+    /// Sanitizes the given path to remove the leading `/` on Windows.
+    ///
+    /// On macOS and Linux this is a no-op.
+    ///
+    /// This is a workaround for https://github.com/bytecodealliance/wasmtime/issues/10415.
+    pub fn sanitize_windows_path(path: std::path::PathBuf) -> std::path::PathBuf {
+        use zed_extension_api::{Os, current_platform};
+
+        let (os, _arch) = current_platform();
+        match os {
+            Os::Mac | Os::Linux => path,
+            Os::Windows => path
+                .to_string_lossy()
+                .to_string()
+                .trim_start_matches('/')
+                .into(),
+        }
+    }
+}


### PR DESCRIPTION
Based on: https://github.com/zed-extensions/emmet/commit/5dbed9d7af3e3a7638b363d73945badb04702887

I have no idea if this works