### PR TITLE
Bump zed-oxc and zed_extension_api to v0.3.2 and v0.7.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -732,16 +732,16 @@ dependencies = [
 
 [[package]]
 name = "zed-oxc"
-version = "0.3.1"
+version = "0.3.2"
 dependencies = [
  "zed_extension_api",
 ]
 
 [[package]]
 name = "zed_extension_api"
-version = "0.6.0"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a3ee021e3a4c69d6ae90137fcf7537d1a8a5032dc9bf180c8fa6dd1a2f7c56d7"
+checksum = "0729d50b4ca0a7e28e590bbe32e3ca0194d97ef654961451a424c661a366fca0"
 dependencies = [
  "serde",
  "serde_json",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "zed-oxc"
-version = "0.3.1"
+version = "0.3.2"
 edition = "2024"
 license = "MIT"
 publish = false
@@ -10,4 +10,4 @@ crate-type = ["cdylib"]
 path = "src/oxc.rs"
 
 [dependencies]
-zed_extension_api = "0.6.0"
+zed_extension_api = "0.7.0"

--- a/extension.toml
+++ b/extension.toml
@@ -4,10 +4,10 @@ id = "oxc"
 name = "Oxc"
 repository = "https://github.com/oxc-project/zed-oxc"
 schema_version = 1
-version = "0.3.1"
+version = "0.3.2"
 
 [language_servers.oxc]
-code_actions_kind = ["", "quickfix"]
+code_actions_kind = ["quickfix","source.fixAll.oxc"]
 language = "JavaScript"
 languages = [
     "JavaScript",


### PR DESCRIPTION
Add new code action kind "source.fixAll.oxc" to extension.toml configuration