### PR TITLE
chore: release v0.4.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,31 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+## [0.4.1](https://github.com/oxc-project/oxc-zed/compare/v0.4.0...v0.4.1) - 2025-12-25
+
+### Added
+
+- Add justfile to make it easier for contributors to run pre PR checks ([#49](https://github.com/oxc-project/oxc-zed/pull/49))
+- Allow supplying binary.env configuration without binary.arguments or binary.path ([#48](https://github.com/oxc-project/oxc-zed/pull/48))
+
+### Fixed
+
+- Update exe lookup to avoid node_modules/.bin due to PNPM using bash scripts ([#55](https://github.com/oxc-project/oxc-zed/pull/55))
+- Add wasm extension target ([#54](https://github.com/oxc-project/oxc-zed/pull/54))
+- LSP from workspace ([#53](https://github.com/oxc-project/oxc-zed/pull/53))
+- Don't panic when both binary.arguments and binary.path are missing ([#50](https://github.com/oxc-project/oxc-zed/pull/50))
+
+### Other
+
+- auto update `extensions.yml`
+- Update maintenance instructions for version file
+- *(justfile)* use `just ready` across oxc
+- add MAINTENANCE.md for release instructions
+- Allow relative path for OXLINT_TSGOLINT_PATH env variable ([#47](https://github.com/oxc-project/oxc-zed/pull/47))
+- Remove HashMap import to fix clippy disallowed_types warnings

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oxc-zed"
-version = "0.4.0"
+version = "0.4.1"
 dependencies = [
  "log",
  "simple_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc-zed"
-version = "0.4.0"
+version = "0.4.1"
 edition = "2024"
 license = "MIT"
 description = "Oxc Zed Extension"

--- a/extension.toml
+++ b/extension.toml
@@ -4,7 +4,7 @@ id = "oxc"
 name = "Oxc"
 repository = "https://github.com/oxc-project/zed-oxc"
 schema_version = 1
-version = "0.4.0"
+version = "0.4.1"
 
 [language_servers.oxlint]
 code_actions_kind = ["quickfix", "source.fixAll.oxc"]


### PR DESCRIPTION



## 🤖 New release

* `oxc-zed`: 0.4.0 -> 0.4.1

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.1](https://github.com/oxc-project/oxc-zed/compare/v0.4.0...v0.4.1) - 2025-12-25

### Added

- Add justfile to make it easier for contributors to run pre PR checks ([#49](https://github.com/oxc-project/oxc-zed/pull/49))
- Allow supplying binary.env configuration without binary.arguments or binary.path ([#48](https://github.com/oxc-project/oxc-zed/pull/48))

### Fixed

- Update exe lookup to avoid node_modules/.bin due to PNPM using bash scripts ([#55](https://github.com/oxc-project/oxc-zed/pull/55))
- Add wasm extension target ([#54](https://github.com/oxc-project/oxc-zed/pull/54))
- LSP from workspace ([#53](https://github.com/oxc-project/oxc-zed/pull/53))
- Don't panic when both binary.arguments and binary.path are missing ([#50](https://github.com/oxc-project/oxc-zed/pull/50))

### Other

- auto update `extensions.yml`
- Update maintenance instructions for version file
- *(justfile)* use `just ready` across oxc
- add MAINTENANCE.md for release instructions
- Allow relative path for OXLINT_TSGOLINT_PATH env variable ([#47](https://github.com/oxc-project/oxc-zed/pull/47))
- Remove HashMap import to fix clippy disallowed_types warnings
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).