### PR TITLE
Allow relative path for OXLINT_TSGOLINT_PATH env variable

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -61,6 +61,12 @@ pub trait ZedLspSupport: Send + Sync {
         worktree: &Worktree,
     ) -> Result<Option<Value>>;
 
+    fn language_server_workspace_configuration(
+        &self,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<Option<Value>>;
+
     fn update_extension_language_server_if_outdated(
         &self,
         language_server_id: &LanguageServerId,

--- a/src/oxc.rs
+++ b/src/oxc.rs
@@ -127,6 +127,14 @@ impl Extension for OxcExtension {
         language_server_id: &LanguageServerId,
         worktree: &Worktree,
     ) -> Result<Option<Value>> {
+        if self.is_oxfmt_language_server(language_server_id) {
+            return self
+                .oxfmt_lsp
+                .read()
+                .unwrap()
+                .language_server_workspace_configuration(language_server_id, worktree);
+        }
+
         if self.is_oxlint_language_server(language_server_id) {
             return self
                 .oxlint_lsp
@@ -135,7 +143,9 @@ impl Extension for OxcExtension {
                 .language_server_workspace_configuration(language_server_id, worktree);
         }
 
-        Ok(None)
+        Err(format!(
+            "Unsupported language server id: {language_server_id:?}"
+        ))
     }
 }
 

--- a/src/oxfmt.rs
+++ b/src/oxfmt.rs
@@ -59,4 +59,17 @@ impl ZedLspSupport for ZedOxfmtLsp {
 
         Ok(settings.initialization_options)
     }
+
+    fn language_server_workspace_configuration(
+        &self,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<Option<Value>> {
+        Ok(
+            LspSettings::for_worktree(language_server_id.as_ref(), worktree)?
+                .initialization_options
+                .as_ref()
+                .and_then(|v| v.get("settings").cloned()),
+        )
+    }
 }

--- a/src/oxlint.rs
+++ b/src/oxlint.rs
@@ -11,19 +11,6 @@ impl ZedOxlintLsp {
     pub fn new() -> Self {
         ZedOxlintLsp {}
     }
-
-    pub fn language_server_workspace_configuration(
-        &self,
-        language_server_id: &LanguageServerId,
-        worktree: &Worktree,
-    ) -> Result<Option<Value>> {
-        Ok(
-            LspSettings::for_worktree(language_server_id.as_ref(), worktree)?
-                .initialization_options
-                .as_ref()
-                .and_then(|v| v.get("settings").cloned()),
-        )
-    }
 }
 
 impl ZedLspSupport for ZedOxlintLsp {
@@ -73,6 +60,19 @@ impl ZedLspSupport for ZedOxlintLsp {
         debug!("Oxlint Settings: {settings:?}");
 
         Ok(settings.initialization_options)
+    }
+
+    fn language_server_workspace_configuration(
+        &self,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<Option<Value>> {
+        Ok(
+            LspSettings::for_worktree(language_server_id.as_ref(), worktree)?
+                .initialization_options
+                .as_ref()
+                .and_then(|v| v.get("settings").cloned()),
+        )
     }
 }
 


### PR DESCRIPTION
Similar to https://github.com/oxc-project/oxc/pull/16921

Works with both absolute and project relative paths


example config: 


```json
"lsp": {
    "oxlint": {
      "binary": {
        "path": "frontend/node_modules/.bin/oxlint",
        "arguments": ["--lsp"],
        "env": {
          "OXLINT_TSGOLINT_PATH": "frontend/node_modules/.bin/tsgolint",
        },
      },
      "initialization_options": {
        "settings": {
          "configPath": "frontend/.oxlintrc.json",
          "tsConfigPath": "frontend/tsconfig.json",
          "typeAware": true,
          "run": "onType",
          "fixKind": "safe_fix",
          "unusedDisableDirectives": "deny",
          "disableNestedConfig": false,
        },
      },
    },
}
```