### PR TITLE
feat(oxfmt): add JSON and JSONC language support

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -35,11 +35,15 @@ languages = [
     "JavaScript",
     "JSX",
     "TypeScript",
-    "TSX"
+    "TSX",
+    "JSON",
+    "JSONC",
 ]
 name = "Oxfmt Language Server"
 
 [language_servers.oxfmt.language_ids]
+"JSON" = "json"
+"JSONC" = "jsonc"
 "JSX" = "javascriptreact"
 "JavaScript" = "javascript"
 "TSX" = "typescriptreact"


### PR DESCRIPTION
## Summary
- Add JSON and JSONC to oxfmt language server supported languages
- Enables format-on-save for JSON files via oxfmt in Zed

## Changes
- Added `JSON` and `JSONC` to `language_servers.oxfmt.languages` array
- Added language ID mappings: `"JSON" = "json"`, `"JSONC" = "jsonc"`

## Testing
Verified that `oxfmt` CLI already supports JSON formatting. This change allows Zed to route JSON formatting requests to the oxfmt language server.