### PR TITLE
chore: release v0.4.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,20 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.2](https://github.com/oxc-project/oxc-zed/compare/v0.4.1...v0.4.2) - 2026-01-03
+
+### Added
+
+- Additional debug logging ([#63](https://github.com/oxc-project/oxc-zed/pull/63))
+
+### Other
+
+- Add example projects for oxfmt and oxlint ([#62](https://github.com/oxc-project/oxc-zed/pull/62))
+- update repository in extension.toml
+- *(deps)* update crate-ci/typos action to v1.40.1 ([#59](https://github.com/oxc-project/oxc-zed/pull/59))
+- update description in extension.toml
+- change authors to Boshen so it looks legit in the extension store
+
 ## [0.4.1](https://github.com/oxc-project/oxc-zed/compare/v0.4.0...v0.4.1) - 2025-12-25
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oxc-zed"
-version = "0.4.1"
+version = "0.4.2"
 dependencies = [
  "log",
  "simple_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc-zed"
-version = "0.4.1"
+version = "0.4.2"
 edition = "2024"
 license = "MIT"
 description = "Oxc Zed Extension"

--- a/extension.toml
+++ b/extension.toml
@@ -4,7 +4,7 @@ id = "oxc"
 name = "Oxc"
 repository = "https://github.com/oxc-project/oxc-zed"
 schema_version = 1
-version = "0.4.1"
+version = "0.4.2"
 
 [language_servers.oxlint]
 code_actions_kind = ["quickfix", "source.fixAll.oxc"]


### PR DESCRIPTION



## 🤖 New release

* `oxc-zed`: 0.4.1 -> 0.4.2

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.2](https://github.com/oxc-project/oxc-zed/compare/v0.4.1...v0.4.2) - 2026-01-03

### Added

- Additional debug logging ([#63](https://github.com/oxc-project/oxc-zed/pull/63))

### Other

- Add example projects for oxfmt and oxlint ([#62](https://github.com/oxc-project/oxc-zed/pull/62))
- update repository in extension.toml
- *(deps)* update crate-ci/typos action to v1.40.1 ([#59](https://github.com/oxc-project/oxc-zed/pull/59))
- update description in extension.toml
- change authors to Boshen so it looks legit in the extension store
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).