### PR TITLE
chore: release v0.4.3

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,24 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.3](https://github.com/oxc-project/oxc-zed/compare/v0.4.2...v0.4.3) - 2026-01-10
+
+### Added
+
+- add languages that oxfmt supports ([#73](https://github.com/oxc-project/oxc-zed/pull/73))
+
+### Other
+
+- Update the readme with supported languages ([#74](https://github.com/oxc-project/oxc-zed/pull/74))
+- *(deps)* update crate-ci/typos action to v1.42.0 ([#72](https://github.com/oxc-project/oxc-zed/pull/72))
+- *(deps)* update dependency oxlint to v1.38.0 ([#71](https://github.com/oxc-project/oxc-zed/pull/71))
+- *(deps)* update dependency oxfmt to v0.23.0 ([#70](https://github.com/oxc-project/oxc-zed/pull/70))
+- Remove configuration examples from the README and link to the examples folder ([#68](https://github.com/oxc-project/oxc-zed/pull/68))
+- *(deps)* update dependency oxlint to v1.37.0 ([#65](https://github.com/oxc-project/oxc-zed/pull/65))
+- *(deps)* update dependency oxfmt to v0.22.0 ([#64](https://github.com/oxc-project/oxc-zed/pull/64))
+- Clean up oxfmt settings configuration ([#66](https://github.com/oxc-project/oxc-zed/pull/66))
+- *(deps)* update crate-ci/typos action to v1.41.0 ([#61](https://github.com/oxc-project/oxc-zed/pull/61))
+
 ## [0.4.2](https://github.com/oxc-project/oxc-zed/compare/v0.4.1...v0.4.2) - 2026-01-03
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oxc-zed"
-version = "0.4.2"
+version = "0.4.3"
 dependencies = [
  "log",
  "simple_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc-zed"
-version = "0.4.2"
+version = "0.4.3"
 edition = "2024"
 license = "MIT"
 description = "Oxc Zed Extension"

--- a/extension.toml
+++ b/extension.toml
@@ -4,7 +4,7 @@ id = "oxc"
 name = "Oxc"
 repository = "https://github.com/oxc-project/oxc-zed"
 schema_version = 1
-version = "0.4.2"
+version = "0.4.3"
 
 [language_servers.oxlint]
 code_actions_kind = ["quickfix", "source.fixAll.oxc"]


### PR DESCRIPTION



## 🤖 New release

* `oxc-zed`: 0.4.2 -> 0.4.3

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.3](https://github.com/oxc-project/oxc-zed/compare/v0.4.2...v0.4.3) - 2026-01-10

### Added

- add languages that oxfmt supports ([#73](https://github.com/oxc-project/oxc-zed/pull/73))

### Other

- Update the readme with supported languages ([#74](https://github.com/oxc-project/oxc-zed/pull/74))
- *(deps)* update crate-ci/typos action to v1.42.0 ([#72](https://github.com/oxc-project/oxc-zed/pull/72))
- *(deps)* update dependency oxlint to v1.38.0 ([#71](https://github.com/oxc-project/oxc-zed/pull/71))
- *(deps)* update dependency oxfmt to v0.23.0 ([#70](https://github.com/oxc-project/oxc-zed/pull/70))
- Remove configuration examples from the README and link to the examples folder ([#68](https://github.com/oxc-project/oxc-zed/pull/68))
- *(deps)* update dependency oxlint to v1.37.0 ([#65](https://github.com/oxc-project/oxc-zed/pull/65))
- *(deps)* update dependency oxfmt to v0.22.0 ([#64](https://github.com/oxc-project/oxc-zed/pull/64))
- Clean up oxfmt settings configuration ([#66](https://github.com/oxc-project/oxc-zed/pull/66))
- *(deps)* update crate-ci/typos action to v1.41.0 ([#61](https://github.com/oxc-project/oxc-zed/pull/61))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).