### PR TITLE
chore: release v0.4.4

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,37 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.4](https://github.com/oxc-project/oxc-zed/compare/v0.4.3...v0.4.4) - 2026-02-06
+
+### Other
+
+- *(deps)* update crate-ci/typos action to v1.43.3 ([#108](https://github.com/oxc-project/oxc-zed/pull/108))
+- *(deps)* update crate-ci/typos action to v1.43.2 ([#107](https://github.com/oxc-project/oxc-zed/pull/107))
+- Remove JSX formatting settings from settings.json ([#106](https://github.com/oxc-project/oxc-zed/pull/106))
+- *(deps)* update crate-ci/typos action to v1.43.1 ([#105](https://github.com/oxc-project/oxc-zed/pull/105))
+- *(deps)* update crate-ci/typos action to v1.43.0 ([#104](https://github.com/oxc-project/oxc-zed/pull/104))
+- *(deps)* update oxc apps ([#103](https://github.com/oxc-project/oxc-zed/pull/103))
+- *(deps)* update pnpm to v10.28.2 ([#102](https://github.com/oxc-project/oxc-zed/pull/102))
+- *(deps)* update crate-ci/typos action to v1.42.3 ([#100](https://github.com/oxc-project/oxc-zed/pull/100))
+- *(deps)* update oxc apps ([#99](https://github.com/oxc-project/oxc-zed/pull/99))
+- *(deps)* update crate-ci/typos action to v1.42.2 ([#98](https://github.com/oxc-project/oxc-zed/pull/98))
+- *(deps)* update github-actions ([#94](https://github.com/oxc-project/oxc-zed/pull/94))
+- *(deps)* update pnpm to v10.28.1 ([#95](https://github.com/oxc-project/oxc-zed/pull/95))
+- *(deps)* update dependency rust to v1.93.0 ([#92](https://github.com/oxc-project/oxc-zed/pull/92))
+- *(deps)* update oxc apps ([#91](https://github.com/oxc-project/oxc-zed/pull/91))
+- *(deps)* update crate-ci/typos action to v1.42.1 ([#90](https://github.com/oxc-project/oxc-zed/pull/90))
+- *(deps)* update dependency oxfmt to v0.25.0 ([#89](https://github.com/oxc-project/oxc-zed/pull/89))
+- *(deps)* update pnpm to v10.28.0 ([#88](https://github.com/oxc-project/oxc-zed/pull/88))
+- update logo ([#86](https://github.com/oxc-project/oxc-zed/pull/86))
+- Document oxlint v1.35.0+ requirement ([#85](https://github.com/oxc-project/oxc-zed/pull/85))
+- update README
+- *(deps)* update oxc apps ([#83](https://github.com/oxc-project/oxc-zed/pull/83))
+- add renovate.json
+- add example for both
+- update oxfmt example
+- *(deps)* update taiki-e/checkout-action action to v1.3.2 ([#77](https://github.com/oxc-project/oxc-zed/pull/77))
+- Add steps on how to update the Git submodule in the Zed extensions repo ([#75](https://github.com/oxc-project/oxc-zed/pull/75))
+
 ## [0.4.3](https://github.com/oxc-project/oxc-zed/compare/v0.4.2...v0.4.3) - 2026-01-10
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oxc-zed"
-version = "0.4.3"
+version = "0.4.4"
 dependencies = [
  "log",
  "simple_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc-zed"
-version = "0.4.3"
+version = "0.4.4"
 edition = "2024"
 license = "MIT"
 description = "Oxc Zed Extension"

--- a/extension.toml
+++ b/extension.toml
@@ -4,7 +4,7 @@ id = "oxc"
 name = "Oxc"
 repository = "https://github.com/oxc-project/oxc-zed"
 schema_version = 1
-version = "0.4.3"
+version = "0.4.4"
 
 [language_servers.oxlint]
 code_actions_kind = ["quickfix", "source.fixAll.oxc"]


### PR DESCRIPTION



## 🤖 New release

* `oxc-zed`: 0.4.3 -> 0.4.4

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.4](https://github.com/oxc-project/oxc-zed/compare/v0.4.3...v0.4.4) - 2026-02-06

### Other

- *(deps)* update crate-ci/typos action to v1.43.3 ([#108](https://github.com/oxc-project/oxc-zed/pull/108))
- *(deps)* update crate-ci/typos action to v1.43.2 ([#107](https://github.com/oxc-project/oxc-zed/pull/107))
- Remove JSX formatting settings from settings.json ([#106](https://github.com/oxc-project/oxc-zed/pull/106))
- *(deps)* update crate-ci/typos action to v1.43.1 ([#105](https://github.com/oxc-project/oxc-zed/pull/105))
- *(deps)* update crate-ci/typos action to v1.43.0 ([#104](https://github.com/oxc-project/oxc-zed/pull/104))
- *(deps)* update oxc apps ([#103](https://github.com/oxc-project/oxc-zed/pull/103))
- *(deps)* update pnpm to v10.28.2 ([#102](https://github.com/oxc-project/oxc-zed/pull/102))
- *(deps)* update crate-ci/typos action to v1.42.3 ([#100](https://github.com/oxc-project/oxc-zed/pull/100))
- *(deps)* update oxc apps ([#99](https://github.com/oxc-project/oxc-zed/pull/99))
- *(deps)* update crate-ci/typos action to v1.42.2 ([#98](https://github.com/oxc-project/oxc-zed/pull/98))
- *(deps)* update github-actions ([#94](https://github.com/oxc-project/oxc-zed/pull/94))
- *(deps)* update pnpm to v10.28.1 ([#95](https://github.com/oxc-project/oxc-zed/pull/95))
- *(deps)* update dependency rust to v1.93.0 ([#92](https://github.com/oxc-project/oxc-zed/pull/92))
- *(deps)* update oxc apps ([#91](https://github.com/oxc-project/oxc-zed/pull/91))
- *(deps)* update crate-ci/typos action to v1.42.1 ([#90](https://github.com/oxc-project/oxc-zed/pull/90))
- *(deps)* update dependency oxfmt to v0.25.0 ([#89](https://github.com/oxc-project/oxc-zed/pull/89))
- *(deps)* update pnpm to v10.28.0 ([#88](https://github.com/oxc-project/oxc-zed/pull/88))
- update logo ([#86](https://github.com/oxc-project/oxc-zed/pull/86))
- Document oxlint v1.35.0+ requirement ([#85](https://github.com/oxc-project/oxc-zed/pull/85))
- update README
- *(deps)* update oxc apps ([#83](https://github.com/oxc-project/oxc-zed/pull/83))
- add renovate.json
- add example for both
- update oxfmt example
- *(deps)* update taiki-e/checkout-action action to v1.3.2 ([#77](https://github.com/oxc-project/oxc-zed/pull/77))
- Add steps on how to update the Git submodule in the Zed extensions repo ([#75](https://github.com/oxc-project/oxc-zed/pull/75))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).