### PR TITLE
chore: release v0.4.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,47 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.5](https://github.com/oxc-project/oxc-zed/compare/v0.4.4...v0.4.5) - 2026-03-31
+
+### Added
+
+- Support LSP from vite-plus ([#141](https://github.com/oxc-project/oxc-zed/pull/141))
+
+### Other
+
+- *(deps)* update pnpm to v10.33.0 ([#154](https://github.com/oxc-project/oxc-zed/pull/154))
+- *(deps)* update oxc apps ([#153](https://github.com/oxc-project/oxc-zed/pull/153))
+- *(deps)* update dependency rust to v1.94.1 ([#151](https://github.com/oxc-project/oxc-zed/pull/151))
+- *(deps)* update oxc apps ([#148](https://github.com/oxc-project/oxc-zed/pull/148))
+- *(deps)* update oxc apps ([#143](https://github.com/oxc-project/oxc-zed/pull/143))
+- *(deps)* update oxc-project/setup-rust action to v1.0.16 ([#142](https://github.com/oxc-project/oxc-zed/pull/142))
+- *(deps)* update oxc apps ([#140](https://github.com/oxc-project/oxc-zed/pull/140))
+- *(deps)* update oxc apps ([#139](https://github.com/oxc-project/oxc-zed/pull/139))
+- *(deps)* update oxc apps ([#137](https://github.com/oxc-project/oxc-zed/pull/137))
+- *(deps)* update oxc apps ([#136](https://github.com/oxc-project/oxc-zed/pull/136))
+- *(deps)* update github-actions ([#135](https://github.com/oxc-project/oxc-zed/pull/135))
+- *(deps)* update dependency rust to v1.94.0 ([#134](https://github.com/oxc-project/oxc-zed/pull/134))
+- Remove `typeAware` option from zed settings ([#132](https://github.com/oxc-project/oxc-zed/pull/132))
+- migrate oxlint CLI type flags to config options ([#131](https://github.com/oxc-project/oxc-zed/pull/131))
+- *(deps)* update oxc apps ([#130](https://github.com/oxc-project/oxc-zed/pull/130))
+- *(deps)* update oxc-project/setup-rust action to v1.0.13 ([#129](https://github.com/oxc-project/oxc-zed/pull/129))
+- *(deps)* update pnpm to v10.30.2 ([#127](https://github.com/oxc-project/oxc-zed/pull/127))
+- *(deps)* update crate-ci/typos action to v1.44.0 ([#126](https://github.com/oxc-project/oxc-zed/pull/126))
+- *(deps)* update oxc apps ([#124](https://github.com/oxc-project/oxc-zed/pull/124))
+- *(deps)* update rust crate simple_logger to v5.2.0 ([#123](https://github.com/oxc-project/oxc-zed/pull/123))
+- *(deps)* update pnpm to v10.30.0 ([#122](https://github.com/oxc-project/oxc-zed/pull/122))
+- *(deps)* update oxc apps ([#121](https://github.com/oxc-project/oxc-zed/pull/121))
+- *(deps)* update dependency oxlint to v1.48.0 ([#120](https://github.com/oxc-project/oxc-zed/pull/120))
+- *(deps)* update crate-ci/typos action to v1.43.5 ([#119](https://github.com/oxc-project/oxc-zed/pull/119))
+- *(deps)* update dependency oxfmt to v0.33.0 ([#118](https://github.com/oxc-project/oxc-zed/pull/118))
+- *(deps)* update pnpm to v10.29.3 ([#117](https://github.com/oxc-project/oxc-zed/pull/117))
+- *(deps)* update dependency rust to v1.93.1 ([#116](https://github.com/oxc-project/oxc-zed/pull/116))
+- *(deps)* update oxc apps ([#115](https://github.com/oxc-project/oxc-zed/pull/115))
+- fix oxfmt configPath arg in both example ([#114](https://github.com/oxc-project/oxc-zed/pull/114))
+- *(deps)* update dependency oxlint to v1.46.0 ([#112](https://github.com/oxc-project/oxc-zed/pull/112))
+- *(deps)* update oxc apps ([#111](https://github.com/oxc-project/oxc-zed/pull/111))
+- *(deps)* update crate-ci/typos action to v1.43.4 ([#109](https://github.com/oxc-project/oxc-zed/pull/109))
+
 ## [0.4.4](https://github.com/oxc-project/oxc-zed/compare/v0.4.3...v0.4.4) - 2026-02-06
 
 ### Other

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oxc-zed"
-version = "0.4.4"
+version = "0.4.5"
 dependencies = [
  "log",
  "simple_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc-zed"
-version = "0.4.4"
+version = "0.4.5"
 edition = "2024"
 license = "MIT"
 description = "Oxc Zed Extension"

--- a/extension.toml
+++ b/extension.toml
@@ -4,7 +4,7 @@ id = "oxc"
 name = "Oxc"
 repository = "https://github.com/oxc-project/oxc-zed"
 schema_version = 1
-version = "0.4.4"
+version = "0.4.5"
 
 [language_servers.oxlint]
 code_actions_kind = ["quickfix", "source.fixAll.oxc"]


### PR DESCRIPTION



## 🤖 New release

* `oxc-zed`: 0.4.4 -> 0.4.5

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.5](https://github.com/oxc-project/oxc-zed/compare/v0.4.4...v0.4.5) - 2026-03-31

### Added

- Support LSP from vite-plus ([#141](https://github.com/oxc-project/oxc-zed/pull/141))

### Other

- *(deps)* update pnpm to v10.33.0 ([#154](https://github.com/oxc-project/oxc-zed/pull/154))
- *(deps)* update oxc apps ([#153](https://github.com/oxc-project/oxc-zed/pull/153))
- *(deps)* update dependency rust to v1.94.1 ([#151](https://github.com/oxc-project/oxc-zed/pull/151))
- *(deps)* update oxc apps ([#148](https://github.com/oxc-project/oxc-zed/pull/148))
- *(deps)* update oxc apps ([#143](https://github.com/oxc-project/oxc-zed/pull/143))
- *(deps)* update oxc-project/setup-rust action to v1.0.16 ([#142](https://github.com/oxc-project/oxc-zed/pull/142))
- *(deps)* update oxc apps ([#140](https://github.com/oxc-project/oxc-zed/pull/140))
- *(deps)* update oxc apps ([#139](https://github.com/oxc-project/oxc-zed/pull/139))
- *(deps)* update oxc apps ([#137](https://github.com/oxc-project/oxc-zed/pull/137))
- *(deps)* update oxc apps ([#136](https://github.com/oxc-project/oxc-zed/pull/136))
- *(deps)* update github-actions ([#135](https://github.com/oxc-project/oxc-zed/pull/135))
- *(deps)* update dependency rust to v1.94.0 ([#134](https://github.com/oxc-project/oxc-zed/pull/134))
- Remove `typeAware` option from zed settings ([#132](https://github.com/oxc-project/oxc-zed/pull/132))
- migrate oxlint CLI type flags to config options ([#131](https://github.com/oxc-project/oxc-zed/pull/131))
- *(deps)* update oxc apps ([#130](https://github.com/oxc-project/oxc-zed/pull/130))
- *(deps)* update oxc-project/setup-rust action to v1.0.13 ([#129](https://github.com/oxc-project/oxc-zed/pull/129))
- *(deps)* update pnpm to v10.30.2 ([#127](https://github.com/oxc-project/oxc-zed/pull/127))
- *(deps)* update crate-ci/typos action to v1.44.0 ([#126](https://github.com/oxc-project/oxc-zed/pull/126))
- *(deps)* update oxc apps ([#124](https://github.com/oxc-project/oxc-zed/pull/124))
- *(deps)* update rust crate simple_logger to v5.2.0 ([#123](https://github.com/oxc-project/oxc-zed/pull/123))
- *(deps)* update pnpm to v10.30.0 ([#122](https://github.com/oxc-project/oxc-zed/pull/122))
- *(deps)* update oxc apps ([#121](https://github.com/oxc-project/oxc-zed/pull/121))
- *(deps)* update dependency oxlint to v1.48.0 ([#120](https://github.com/oxc-project/oxc-zed/pull/120))
- *(deps)* update crate-ci/typos action to v1.43.5 ([#119](https://github.com/oxc-project/oxc-zed/pull/119))
- *(deps)* update dependency oxfmt to v0.33.0 ([#118](https://github.com/oxc-project/oxc-zed/pull/118))
- *(deps)* update pnpm to v10.29.3 ([#117](https://github.com/oxc-project/oxc-zed/pull/117))
- *(deps)* update dependency rust to v1.93.1 ([#116](https://github.com/oxc-project/oxc-zed/pull/116))
- *(deps)* update oxc apps ([#115](https://github.com/oxc-project/oxc-zed/pull/115))
- fix oxfmt configPath arg in both example ([#114](https://github.com/oxc-project/oxc-zed/pull/114))
- *(deps)* update dependency oxlint to v1.46.0 ([#112](https://github.com/oxc-project/oxc-zed/pull/112))
- *(deps)* update oxc apps ([#111](https://github.com/oxc-project/oxc-zed/pull/111))
- *(deps)* update crate-ci/typos action to v1.43.4 ([#109](https://github.com/oxc-project/oxc-zed/pull/109))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).