### PR TITLE
Remove `typeAware` option from zed settings

### DIFF
--- a/examples/both/.zed/settings.json
+++ b/examples/both/.zed/settings.json
@@ -7,7 +7,6 @@
           "run": "onType",
           "disableNestedConfig": false,
           "fixKind": "safe_fix",
-          "typeAware": true,
           "unusedDisableDirectives": "deny"
         }
       }

--- a/examples/oxlint/custom-config/.zed/settings.json
+++ b/examples/oxlint/custom-config/.zed/settings.json
@@ -22,7 +22,6 @@
           "disableNestedConfig": false,
           "fixKind": "safe_fix",
           "run": "onType",
-          "typeAware": true,
           "unusedDisableDirectives": "deny",
         },
       },

--- a/examples/oxlint/nested-configs/.zed/settings.json
+++ b/examples/oxlint/nested-configs/.zed/settings.json
@@ -21,7 +21,6 @@
           "disableNestedConfig": false,
           "fixKind": "safe_fix",
           "run": "onType",
-          "typeAware": true,
           "unusedDisableDirectives": "deny",
         },
       },


### PR DESCRIPTION
Since `typeAware` is now part of the oxlint config, the option in Zed settings is no longer necessary.