### PR TITLE
feat: Support LSP from vite-plus

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -12,7 +12,7 @@ pub const OXLINT_SERVER_ID: &str = "oxlint";
 pub const OXFMT_SERVER_ID: &str = "oxfmt";
 
 pub trait ZedLspSupport: Send + Sync {
-    fn exe_exists(&self, worktree: &Worktree) -> Result<bool> {
+    fn get_workspace_exe_path(&self, worktree: &Worktree) -> Result<Option<PathBuf>> {
         // Reading files from node_modules doesn't seem to be possible now,
         // https://github.com/zed-industries/zed/issues/10760.
         // Instead we try to read the `package.json`, see if the package is installed
@@ -21,35 +21,50 @@ pub trait ZedLspSupport: Send + Sync {
             .unwrap_or(String::from(r#"{}"#));
 
         let package_json: Option<Value> = from_str(package_json.as_str()).ok();
-
         let package_name = self.get_package_name();
-        Ok(package_json.is_some_and(|f| {
-            !f["dependencies"][&package_name].is_null()
-                || !f["devDependencies"][&package_name].is_null()
-        }))
+        let workspace_root_path = worktree.root_path();
+        let workspace_root = Path::new(workspace_root_path.as_str());
+
+        for package_dir in [package_name.as_str(), "vite-plus"] {
+            if package_json
+                .as_ref()
+                .is_some_and(|package_json| package_exists(package_json, package_dir))
+            {
+                return self
+                    .get_exe_path_from(workspace_root, package_dir, package_name.as_str())
+                    .map(Some);
+            }
+        }
+
+        Ok(None)
     }
 
-    fn get_exe_path_from(&self, from: &Path) -> Result<PathBuf> {
-        let package_name = self.get_package_name();
+    fn exe_exists(&self, worktree: &Worktree) -> Result<bool> {
+        Ok(self.get_workspace_exe_path(worktree)?.is_some())
+    }
 
+    fn get_exe_path_from(&self, from: &Path, package_dir: &str, exe_name: &str) -> Result<PathBuf> {
         // Doesn't use `node_modules/.bin` due to PNPM storing bash scripts there
         // instead of Node.js scripts.
         Ok(from
             .join("node_modules")
-            .join(&package_name)
+            .join(package_dir)
             .join("bin")
-            .join(&package_name))
+            .join(exe_name))
     }
 
     fn get_resolved_exe_path(&self, worktree: &Worktree) -> Result<PathBuf> {
-        if self.exe_exists(worktree)? {
-            let path = self.get_exe_path_from(Path::new(worktree.root_path().as_str()));
+        if let Some(path) = self.get_workspace_exe_path(worktree)? {
             debug!("Found exe installation in worktree at path {path:?}");
-            return path;
+            return Ok(path);
         }
 
-        let path =
-            self.get_exe_path_from(env::current_dir().map_err(|err| err.to_string())?.as_path());
+        let package_name = self.get_package_name();
+        let path = self.get_exe_path_from(
+            env::current_dir().map_err(|err| err.to_string())?.as_path(),
+            package_name.as_str(),
+            package_name.as_str(),
+        );
         debug!("Using exe installation from extension at path {path:?}");
         path
     }
@@ -105,4 +120,9 @@ pub trait ZedLspSupport: Send + Sync {
 
         Ok(())
     }
+}
+
+fn package_exists(package_json: &Value, package_name: &str) -> bool {
+    !package_json["dependencies"][package_name].is_null()
+        || !package_json["devDependencies"][package_name].is_null()
 }


### PR DESCRIPTION
The extension should now be able to use the LSP from the `vite-plus` package. 
It will detect the LSP in this order:
1. `oxlint` or `oxfmt`
2. `vite-plus`