### PR TITLE
fix: add Yarn PnP support via yarn exec

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -4,8 +4,8 @@ use std::path::{Path, PathBuf};
 use zed_extension_api::serde_json::{Value, from_str};
 use zed_extension_api::{
     Command, LanguageServerId, LanguageServerInstallationStatus, Result, Worktree,
-    npm_install_package, npm_package_installed_version, npm_package_latest_version,
-    set_language_server_installation_status,
+    node_binary_path, npm_install_package, npm_package_installed_version,
+    npm_package_latest_version, set_language_server_installation_status,
 };
 
 pub const OXLINT_SERVER_ID: &str = "oxlint";
@@ -52,6 +52,29 @@ pub trait ZedLspSupport: Send + Sync {
             self.get_exe_path_from(env::current_dir().map_err(|err| err.to_string())?.as_path());
         debug!("Using exe installation from extension at path {path:?}");
         path
+    }
+
+    fn is_yarn_pnp(&self, worktree: &Worktree) -> bool {
+        // .pnp.cjs is the canonical Yarn Berry PnP indicator
+        // .pnp.js covers older Yarn Berry projects
+        worktree.read_text_file(".pnp.cjs").is_ok()
+            || worktree.read_text_file(".pnp.js").is_ok()
+    }
+
+    fn get_default_command_and_args(
+        &self,
+        worktree: &Worktree,
+    ) -> Result<(String, Vec<String>)> {
+        if self.exe_exists(worktree)? && self.is_yarn_pnp(worktree) {
+            debug!("Detected Yarn PnP — using yarn exec");
+            return Ok(("yarn".to_string(), vec!["exec".to_string(), self.get_package_name()]));
+        }
+        // Standard node_modules approach (npm / pnpm / yarn --linker=node-modules)
+        let exe_path = self.get_resolved_exe_path(worktree)?;
+        Ok((
+            node_binary_path()?,
+            vec![exe_path.to_string_lossy().to_string()],
+        ))
     }
 
     fn get_package_name(&self) -> String;

--- a/src/oxfmt.rs
+++ b/src/oxfmt.rs
@@ -2,7 +2,7 @@ use crate::lsp::ZedLspSupport;
 use log::debug;
 use zed_extension_api::serde_json::Value;
 use zed_extension_api::settings::LspSettings;
-use zed_extension_api::{Command, EnvVars, LanguageServerId, Result, Worktree, node_binary_path};
+use zed_extension_api::{Command, EnvVars, LanguageServerId, Result, Worktree};
 
 pub struct ZedOxfmtLsp {}
 
@@ -25,13 +25,10 @@ impl ZedLspSupport for ZedOxfmtLsp {
         let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
         debug!("Oxfmt language_server_command LspSettings: {settings:?}");
 
-        let mut args = vec![
-            self.get_resolved_exe_path(worktree)?
-                .to_string_lossy()
-                .to_string(),
-            "--lsp".to_string(),
-        ];
-        let mut command = node_binary_path()?;
+        let (default_command, mut base_args) = self.get_default_command_and_args(worktree)?;
+        base_args.push("--lsp".to_string());
+        let mut command = default_command;
+        let mut args = base_args;
         let mut env = EnvVars::default();
         if let Some(binary) = settings.binary {
             if (binary.path.is_some() && binary.arguments.is_none())

--- a/src/oxlint.rs
+++ b/src/oxlint.rs
@@ -3,7 +3,7 @@ use log::debug;
 use std::path::{Path, PathBuf};
 use zed_extension_api::serde_json::Value;
 use zed_extension_api::settings::LspSettings;
-use zed_extension_api::{Command, EnvVars, LanguageServerId, Result, Worktree, node_binary_path};
+use zed_extension_api::{Command, EnvVars, LanguageServerId, Result, Worktree};
 
 pub struct ZedOxlintLsp {}
 
@@ -26,13 +26,10 @@ impl ZedLspSupport for ZedOxlintLsp {
         let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
         debug!("Oxlint language_server_command LspSettings: {settings:?}");
 
-        let mut args = vec![
-            self.get_resolved_exe_path(worktree)?
-                .to_string_lossy()
-                .to_string(),
-            "--lsp".to_string(),
-        ];
-        let mut command = node_binary_path()?;
+        let (default_command, mut base_args) = self.get_default_command_and_args(worktree)?;
+        base_args.push("--lsp".to_string());
+        let mut command = default_command;
+        let mut args = base_args;
         let mut env = EnvVars::default();
         if let Some(binary) = settings.binary {
             if (binary.path.is_some() && binary.arguments.is_none())


### PR DESCRIPTION
## Problem

The plugin fails in projects using Yarn PnP mode because it hardcodes paths like `node_modules/{pkg}/bin/{pkg}`. Under Yarn PnP, there is no `node_modules` on disk — packages are zip-loaded from `.yarn/cache/`.

## Solution

Detect Yarn PnP by checking for `.pnp.cjs` or `.pnp.js` at the worktree root, and switch the launch strategy:

- **Before**: `node {worktree}/node_modules/oxlint/bin/oxlint --lsp`
- **After (Yarn PnP)**: `yarn exec oxlint --lsp`

## Changes

- `src/lsp.rs`: Added `is_yarn_pnp()` helper and `get_default_command_and_args()` trait method
- `src/oxlint.rs`: Uses `get_default_command_and_args()` instead of manually constructing `node <path>`
- `src/oxfmt.rs`: Same

## Behaviour

| Setup | Result |
|---|---|
| npm / pnpm | `node_modules` present → existing path logic (no regression) |
| Yarn PnP | `.pnp.cjs` present → `yarn exec oxlint --lsp` |
| Yarn `nodeLinker: node-modules` | No `.pnp.cjs` → existing path logic |
| No local install | Falls back to extension-bundled binary |
| Custom binary override in settings | Still applied after detection |