### PR TITLE
chore: release v0.4.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,18 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [0.4.6](https://github.com/oxc-project/oxc-zed/compare/v0.4.5...v0.4.6) - 2026-04-08
+
+### Fixed
+
+- Correct spelling of LESS in extension.toml ([#159](https://github.com/oxc-project/oxc-zed/pull/159))
+
+### Other
+
+- *(deps)* update oxc apps ([#158](https://github.com/oxc-project/oxc-zed/pull/158))
+- *(deps)* update taiki-e/checkout-action action to v1.4.2 ([#157](https://github.com/oxc-project/oxc-zed/pull/157))
+- *(deps)* update crate-ci/typos action to v1.45.0 ([#155](https://github.com/oxc-project/oxc-zed/pull/155))
+
 ## [0.4.5](https://github.com/oxc-project/oxc-zed/compare/v0.4.4...v0.4.5) - 2026-03-31
 
 ### Added

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -403,7 +403,7 @@ checksum = "42f5e15c9953c5e4ccceeb2e7382a716482c34515315f7b03532b8b4e8393d2d"
 
 [[package]]
 name = "oxc-zed"
-version = "0.4.5"
+version = "0.4.6"
 dependencies = [
  "log",
  "simple_logger",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "oxc-zed"
-version = "0.4.5"
+version = "0.4.6"
 edition = "2024"
 license = "MIT"
 description = "Oxc Zed Extension"

--- a/extension.toml
+++ b/extension.toml
@@ -4,7 +4,7 @@ id = "oxc"
 name = "Oxc"
 repository = "https://github.com/oxc-project/oxc-zed"
 schema_version = 1
-version = "0.4.5"
+version = "0.4.6"
 
 [language_servers.oxlint]
 code_actions_kind = ["quickfix", "source.fixAll.oxc"]


### PR DESCRIPTION



## 🤖 New release

* `oxc-zed`: 0.4.5 -> 0.4.6

<details><summary><i><b>Changelog</b></i></summary><p>

<blockquote>

## [0.4.6](https://github.com/oxc-project/oxc-zed/compare/v0.4.5...v0.4.6) - 2026-04-08

### Fixed

- Correct spelling of LESS in extension.toml ([#159](https://github.com/oxc-project/oxc-zed/pull/159))

### Other

- *(deps)* update oxc apps ([#158](https://github.com/oxc-project/oxc-zed/pull/158))
- *(deps)* update taiki-e/checkout-action action to v1.4.2 ([#157](https://github.com/oxc-project/oxc-zed/pull/157))
- *(deps)* update crate-ci/typos action to v1.45.0 ([#155](https://github.com/oxc-project/oxc-zed/pull/155))
</blockquote>


</p></details>

---
This PR was generated with [release-plz](https://github.com/release-plz/release-plz/).