### PR TITLE
chore: update packageManager to pnpm 11.0.4

### DIFF
--- a/examples/both/package.json
+++ b/examples/both/package.json
@@ -1,6 +1,6 @@
 {
   "name": "both",
-  "packageManager": "pnpm@10.33.0",
+  "packageManager": "pnpm@11.0.4",
   "devDependencies": {
     "oxfmt": "^0.45.0",
     "oxlint": "^1.51.0"


### PR DESCRIPTION
## Summary
- update the pnpm package manager pin to `pnpm@11.0.4`
- add missing pnpm package manager metadata where needed
- keep lockfiles unchanged to avoid unrelated dependency updates