### PR TITLE
feat: mark svelte as supported for oxfmt

### DIFF
--- a/extension.toml
+++ b/extension.toml
@@ -43,6 +43,7 @@ languages = [
     "HTML",
     "CSS",
     "SCSS",
+    "Svelte",
     "LESS",
     "GraphQL",
     "Handlebars",
@@ -67,6 +68,7 @@ name = "Oxfmt Language Server"
 "MDX" = "mdx"
 "Markdown" = "markdown"
 "SCSS" = "scss"
+"Svelte" = "svelte"
 "TOML" = "toml"
 "TSX" = "typescriptreact"
 "TypeScript" = "typescript"


### PR DESCRIPTION
Mark svelte as supported for oxfmt to use it as default formatter in zed because as of [this](https://github.com/oxc-project/oxc/releases/tag/apps_v1.64.0) release svelte support is experimental