### PR TITLE
ci: add crates environment to release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,7 @@ jobs:
   release-plz:
     name: Release-plz
     runs-on: ubuntu-latest
+    environment: crates
     permissions:
       pull-requests: write
       contents: write


### PR DESCRIPTION
Adds `environment: crates` to the `release-plz` job in `.github/workflows/release.yml` so releases run through the crates environment.
