### PR TITLE
chore: configure clippy exported api lint

### DIFF
--- a/.clippy.toml
+++ b/.clippy.toml
@@ -1,3 +1,5 @@
+avoid-breaking-exported-api = false
+
 disallowed-types = [
   { path = "std::collections::HashMap", reason = "Use `rustc_hash::FxHashMap` instead, which is typically faster." },
   { path = "std::collections::HashSet", reason = "Use `rustc_hash::FxHashSet` instead, which is typically faster." },


### PR DESCRIPTION
Ensures clippy is clean with `avoid-breaking-exported-api = false`.

Validated with `cargo clippy --workspace --all-targets --all-features`.
