### PR TITLE
chore: standardize rustfmt config

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,0 +1,6 @@
+style_edition = "2024"
+use_small_heuristics = "Max"
+use_field_init_shorthand = true
+reorder_modules = true
+merge_derives = true
+remove_nested_parens = true

--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -16,9 +16,7 @@ pub trait ZedLspSupport: Send + Sync {
         // Reading files from node_modules doesn't seem to be possible now,
         // https://github.com/zed-industries/zed/issues/10760.
         // Instead we try to read the `package.json`, see if the package is installed
-        let package_json = worktree
-            .read_text_file("package.json")
-            .unwrap_or(String::from(r#"{}"#));
+        let package_json = worktree.read_text_file("package.json").unwrap_or(String::from(r#"{}"#));
 
         let package_json: Option<Value> = from_str(package_json.as_str()).ok();
         let package_name = self.get_package_name();
@@ -46,11 +44,7 @@ pub trait ZedLspSupport: Send + Sync {
     fn get_exe_path_from(&self, from: &Path, package_dir: &str, exe_name: &str) -> Result<PathBuf> {
         // Doesn't use `node_modules/.bin` due to PNPM storing bash scripts there
         // instead of Node.js scripts.
-        Ok(from
-            .join("node_modules")
-            .join(package_dir)
-            .join("bin")
-            .join(exe_name))
+        Ok(from.join("node_modules").join(package_dir).join("bin").join(exe_name))
     }
 
     fn get_resolved_exe_path(&self, worktree: &Worktree) -> Result<PathBuf> {

--- a/src/oxc.rs
+++ b/src/oxc.rs
@@ -91,9 +91,7 @@ impl Extension for OxcExtension {
                 .language_server_command(language_server_id, worktree);
         }
 
-        Err(format!(
-            "Unsupported language server id: {language_server_id:?}"
-        ))
+        Err(format!("Unsupported language server id: {language_server_id:?}"))
     }
 
     fn language_server_initialization_options(
@@ -117,9 +115,7 @@ impl Extension for OxcExtension {
                 .language_server_initialization_options(language_server_id, worktree);
         }
 
-        Err(format!(
-            "Unsupported language server id: {language_server_id:?}"
-        ))
+        Err(format!("Unsupported language server id: {language_server_id:?}"))
     }
 
     fn language_server_workspace_configuration(
@@ -143,9 +139,7 @@ impl Extension for OxcExtension {
                 .language_server_workspace_configuration(language_server_id, worktree);
         }
 
-        Err(format!(
-            "Unsupported language server id: {language_server_id:?}"
-        ))
+        Err(format!("Unsupported language server id: {language_server_id:?}"))
     }
 }
 

--- a/src/oxfmt.rs
+++ b/src/oxfmt.rs
@@ -26,9 +26,7 @@ impl ZedLspSupport for ZedOxfmtLsp {
         debug!("Oxfmt language_server_command LspSettings: {settings:?}");
 
         let mut args = vec![
-            self.get_resolved_exe_path(worktree)?
-                .to_string_lossy()
-                .to_string(),
+            self.get_resolved_exe_path(worktree)?.to_string_lossy().to_string(),
             "--lsp".to_string(),
         ];
         let mut command = node_binary_path()?;
@@ -73,9 +71,6 @@ impl ZedLspSupport for ZedOxfmtLsp {
         let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
         debug!("Oxfmt language_server_workspace_configuration LspSettings: {settings:?}");
 
-        Ok(settings
-            .initialization_options
-            .as_ref()
-            .and_then(|v| v.get("settings").cloned()))
+        Ok(settings.initialization_options.as_ref().and_then(|v| v.get("settings").cloned()))
     }
 }

--- a/src/oxlint.rs
+++ b/src/oxlint.rs
@@ -27,9 +27,7 @@ impl ZedLspSupport for ZedOxlintLsp {
         debug!("Oxlint language_server_command LspSettings: {settings:?}");
 
         let mut args = vec![
-            self.get_resolved_exe_path(worktree)?
-                .to_string_lossy()
-                .to_string(),
+            self.get_resolved_exe_path(worktree)?.to_string_lossy().to_string(),
             "--lsp".to_string(),
         ];
         let mut command = node_binary_path()?;
@@ -74,10 +72,7 @@ impl ZedLspSupport for ZedOxlintLsp {
         let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
         debug!("Oxfmt language_server_workspace_configuration LspSettings: {settings:?}");
 
-        Ok(settings
-            .initialization_options
-            .as_ref()
-            .and_then(|v| v.get("settings").cloned()))
+        Ok(settings.initialization_options.as_ref().and_then(|v| v.get("settings").cloned()))
     }
 }
 


### PR DESCRIPTION
Standardizes the Rustfmt config filename and options, then applies cargo fmt.
