### PR TITLE
feat: resolve language servers from worktree PATH

### DIFF
--- a/src/lsp.rs
+++ b/src/lsp.rs
@@ -3,13 +3,27 @@ use std::env;
 use std::path::{Path, PathBuf};
 use zed_extension_api::serde_json::{Value, from_str};
 use zed_extension_api::{
-    Command, LanguageServerId, LanguageServerInstallationStatus, Result, Worktree,
-    npm_install_package, npm_package_installed_version, npm_package_latest_version,
-    set_language_server_installation_status,
+    Command, EnvVars, LanguageServerId, LanguageServerInstallationStatus, Os, Result, Worktree,
+    current_platform, node_binary_path, npm_install_package, npm_package_installed_version,
+    npm_package_latest_version, set_language_server_installation_status,
 };
 
 pub const OXLINT_SERVER_ID: &str = "oxlint";
 pub const OXFMT_SERVER_ID: &str = "oxfmt";
+
+fn get_path_exe_name(package_name: &str, os: Os) -> String {
+    if os == Os::Windows { format!("{package_name}.exe") } else { package_name.to_string() }
+}
+
+pub(crate) fn apply_env_overrides(env: &mut EnvVars, overrides: EnvVars) {
+    for (name, value) in overrides {
+        if let Some((_, existing_value)) = env.iter_mut().find(|(key, _)| key == &name) {
+            *existing_value = value;
+        } else {
+            env.push((name, value));
+        }
+    }
+}
 
 pub trait ZedLspSupport: Send + Sync {
     fn get_workspace_exe_path(&self, worktree: &Worktree) -> Result<Option<PathBuf>> {
@@ -37,30 +51,50 @@ pub trait ZedLspSupport: Send + Sync {
         Ok(None)
     }
 
-    fn exe_exists(&self, worktree: &Worktree) -> Result<bool> {
-        Ok(self.get_workspace_exe_path(worktree)?.is_some())
-    }
-
     fn get_exe_path_from(&self, from: &Path, package_dir: &str, exe_name: &str) -> Result<PathBuf> {
         // Doesn't use `node_modules/.bin` due to PNPM storing bash scripts there
         // instead of Node.js scripts.
         Ok(from.join("node_modules").join(package_dir).join("bin").join(exe_name))
     }
 
-    fn get_resolved_exe_path(&self, worktree: &Worktree) -> Result<PathBuf> {
+    fn get_default_language_server_command(
+        &self,
+        language_server_id: &LanguageServerId,
+        worktree: &Worktree,
+    ) -> Result<Command> {
         if let Some(path) = self.get_workspace_exe_path(worktree)? {
             debug!("Found exe installation in worktree at path {path:?}");
-            return Ok(path);
+            return Ok(Command {
+                command: node_binary_path()?,
+                args: vec![path.to_string_lossy().to_string(), "--lsp".to_string()],
+                env: Default::default(),
+            });
         }
 
         let package_name = self.get_package_name();
+        let path_exe_name = get_path_exe_name(package_name.as_str(), current_platform().0);
+        if let Some(path) = worktree.which(path_exe_name.as_str()) {
+            debug!("Found exe in worktree PATH at path {path:?}");
+            return Ok(Command {
+                command: path,
+                args: vec!["--lsp".to_string()],
+                env: worktree.shell_env(),
+            });
+        }
+
+        self.update_extension_language_server_if_outdated(language_server_id)?;
+
         let path = self.get_exe_path_from(
             env::current_dir().map_err(|err| err.to_string())?.as_path(),
             package_name.as_str(),
             package_name.as_str(),
-        );
+        )?;
         debug!("Using exe installation from extension at path {path:?}");
-        path
+        Ok(Command {
+            command: node_binary_path()?,
+            args: vec![path.to_string_lossy().to_string(), "--lsp".to_string()],
+            env: Default::default(),
+        })
     }
 
     fn get_package_name(&self) -> String;

--- a/src/oxc.rs
+++ b/src/oxc.rs
@@ -27,30 +27,6 @@ impl OxcExtension {
     fn is_oxlint_language_server(&self, language_server_id: &LanguageServerId) -> bool {
         language_server_id.as_ref() == OXLINT_SERVER_ID
     }
-
-    fn update_oxfmt_language_server_if_needed(
-        &self,
-        language_server_id: &LanguageServerId,
-        worktree: &Worktree,
-    ) -> Result<()> {
-        let zed_oxfmt_lsp = self.oxfmt_lsp.read().unwrap();
-        if !zed_oxfmt_lsp.exe_exists(worktree)? {
-            zed_oxfmt_lsp.update_extension_language_server_if_outdated(language_server_id)?;
-        }
-        Ok(())
-    }
-
-    fn update_oxlint_language_server_if_needed(
-        &self,
-        language_server_id: &LanguageServerId,
-        worktree: &Worktree,
-    ) -> Result<()> {
-        let zed_oxlint_lsp = self.oxlint_lsp.read().unwrap();
-        if !zed_oxlint_lsp.exe_exists(worktree)? {
-            zed_oxlint_lsp.update_extension_language_server_if_outdated(language_server_id)?;
-        }
-        Ok(())
-    }
 }
 
 impl Extension for OxcExtension {
@@ -72,8 +48,6 @@ impl Extension for OxcExtension {
         worktree: &Worktree,
     ) -> Result<Command> {
         if self.is_oxfmt_language_server(language_server_id) {
-            self.update_oxfmt_language_server_if_needed(language_server_id, worktree)?;
-
             return self
                 .oxfmt_lsp
                 .read()
@@ -82,8 +56,6 @@ impl Extension for OxcExtension {
         }
 
         if self.is_oxlint_language_server(language_server_id) {
-            self.update_oxlint_language_server_if_needed(language_server_id, worktree)?;
-
             return self
                 .oxlint_lsp
                 .read()

--- a/src/oxfmt.rs
+++ b/src/oxfmt.rs
@@ -1,8 +1,8 @@
-use crate::lsp::ZedLspSupport;
+use crate::lsp::{ZedLspSupport, apply_env_overrides};
 use log::debug;
 use zed_extension_api::serde_json::Value;
 use zed_extension_api::settings::LspSettings;
-use zed_extension_api::{Command, EnvVars, LanguageServerId, Result, Worktree, node_binary_path};
+use zed_extension_api::{Command, LanguageServerId, Result, Worktree};
 
 pub struct ZedOxfmtLsp {}
 
@@ -25,12 +25,6 @@ impl ZedLspSupport for ZedOxfmtLsp {
         let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
         debug!("Oxfmt language_server_command LspSettings: {settings:?}");
 
-        let mut args = vec![
-            self.get_resolved_exe_path(worktree)?.to_string_lossy().to_string(),
-            "--lsp".to_string(),
-        ];
-        let mut command = node_binary_path()?;
-        let mut env = EnvVars::default();
         if let Some(binary) = settings.binary {
             if (binary.path.is_some() && binary.arguments.is_none())
                 || (binary.path.is_none() && binary.arguments.is_some())
@@ -40,16 +34,21 @@ impl ZedLspSupport for ZedOxfmtLsp {
                 );
             }
 
-            if let Some(arguments) = binary.arguments {
-                args = arguments;
+            let has_env = binary.env.is_some();
+            let env = binary.env.unwrap_or_default().into_iter().collect();
+            if let (Some(command), Some(args)) = (binary.path, binary.arguments) {
+                return Ok(Command { command, args, env });
             }
-            if let Some(path) = binary.path {
-                command = path;
+
+            let mut command =
+                self.get_default_language_server_command(language_server_id, worktree)?;
+            if has_env {
+                apply_env_overrides(&mut command.env, env);
             }
-            env = binary.env.unwrap_or_default().into_iter().collect();
+            return Ok(command);
         }
 
-        Ok(Command { command, args, env })
+        self.get_default_language_server_command(language_server_id, worktree)
     }
 
     fn language_server_initialization_options(

--- a/src/oxlint.rs
+++ b/src/oxlint.rs
@@ -1,9 +1,9 @@
-use crate::lsp::ZedLspSupport;
+use crate::lsp::{ZedLspSupport, apply_env_overrides};
 use log::debug;
 use std::path::{Path, PathBuf};
 use zed_extension_api::serde_json::Value;
 use zed_extension_api::settings::LspSettings;
-use zed_extension_api::{Command, EnvVars, LanguageServerId, Result, Worktree, node_binary_path};
+use zed_extension_api::{Command, EnvVars, LanguageServerId, Result, Worktree};
 
 pub struct ZedOxlintLsp {}
 
@@ -26,12 +26,6 @@ impl ZedLspSupport for ZedOxlintLsp {
         let settings = LspSettings::for_worktree(language_server_id.as_ref(), worktree)?;
         debug!("Oxlint language_server_command LspSettings: {settings:?}");
 
-        let mut args = vec![
-            self.get_resolved_exe_path(worktree)?.to_string_lossy().to_string(),
-            "--lsp".to_string(),
-        ];
-        let mut command = node_binary_path()?;
-        let mut env = EnvVars::default();
         if let Some(binary) = settings.binary {
             if (binary.path.is_some() && binary.arguments.is_none())
                 || (binary.path.is_none() && binary.arguments.is_some())
@@ -41,16 +35,21 @@ impl ZedLspSupport for ZedOxlintLsp {
                 );
             }
 
-            if let Some(arguments) = binary.arguments {
-                args = arguments;
+            let has_env = binary.env.is_some();
+            let env = normalize_env(binary.env, worktree)?;
+            if let (Some(command), Some(args)) = (binary.path, binary.arguments) {
+                return Ok(Command { command, args, env });
             }
-            if let Some(path) = binary.path {
-                command = path;
+
+            let mut command =
+                self.get_default_language_server_command(language_server_id, worktree)?;
+            if has_env {
+                apply_env_overrides(&mut command.env, env);
             }
-            env = normalize_env(binary.env, worktree)?;
+            return Ok(command);
         }
 
-        Ok(Command { command, args, env })
+        self.get_default_language_server_command(language_server_id, worktree)
     }
 
     fn language_server_initialization_options(


### PR DESCRIPTION
Closes #234.[^ai]

## Summary

Resolve `oxlint` and `oxfmt` from the worktree's `PATH` before falling back to the extension-managed npm installation.

The resolution order is now:

1. Explicit binary settings
2. Project-local package
3. Worktree `PATH`
4. Extension-managed npm installation

PATH binaries are launched directly with `--lsp` and the worktree shell environment. Configured environment variables are merged on top.

On Windows, PATH resolution is restricted to native `.exe` binaries to avoid selecting npm `.cmd` or `.bat` shims.

## Validation

- `cargo fmt --check`
- `cargo check --all-targets --all-features`
- `cargo test`
- `cargo clippy --all-targets --all-features -- -D warnings`
- `cargo doc --no-deps --document-private-items`

[^ai]: This pr was generated by GPT-5.6 Sol Fast. [View the OpenCode conversation](https://opncd.ai/share/uaOAUyEk).