### PR TITLE
chore(oxc-zed): exclude extraneous files from published crates.io package

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ description = "Oxc Zed Extension"
 homepage = "https://github.com/oxc-project/oxc-zed"
 repository = "https://github.com/oxc-project/oxc-zed"
 publish = true
+include = ["src/**/*", "LICENSE", "README.md", "CHANGELOG.md"]
 
 [lib]
 crate-type = ["cdylib"]


### PR DESCRIPTION
Adds explicit includes for `oxc-zed` to omit 70.0 kB of files (70% of total) under `/examples` and `.github` from the published package

Files removed from the package, by directory:

| Directory | Size | Files |
|---|---|---|
| `examples/**` (mostly `package-lock.json` files) | 60.7 kB | 28 |
| `.github/**` | 4.3 kB | 5 |
| root config (`extension.toml`, `justfile`, `.clippy.toml`, `.rustfmt.toml`, `rust-toolchain.toml`, `.gitignore`) | 2.6 kB | 6 |
| root docs (`CONTRIBUTING.md`, `MAINTENANCE.md`) | 2.4 kB | 2 |

Examples are omitted from the package. I personally feel it's best if the user clones the GitHub repo for those, but glad to change this if desired

As far as I know, zed extensions are based on the GitHub repo and not the crates.io registry, so it should be safe to omit the extension.toml

Verified with publish dry run

Found with [cargo-diet](https://github.com/the-lean-crate/cargo-diet)
