### PR TITLE
chore: reduce Rust dev debug info

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,3 +17,9 @@ path = "src/oxc.rs"
 simple_logger = "5.1.0"
 log = "0.4.29"
 zed_extension_api = "0.7.0"
+
+[profile.dev]
+debug = "line-tables-only"
+
+[profile.dev.package."*"]
+debug = false


### PR DESCRIPTION
Reduces debug information for local Rust builds and disables debug information for dependencies.